### PR TITLE
Initial version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
 
 install:
   - python setup.py develop
-  - pip install flake8 flake8-commas flake8-quotes
+  - pip install -r requirements-dev.txt
 
 script:
   - flake8 .

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+Copyright (c) 2017 Underdog.io
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,9 @@
 typeform
 ========
 
-API Client for [TypeForm](https://typeform.com/).
+API Client for `TypeForm <https://typeform.com>`_.
+
+At the time of writing this client TypeForm only has a data access API for fetching responses to a given form.
 
 
 Getting Started
@@ -19,6 +21,11 @@ Install the module with: ``pip install typeform``
 
    # Fetch responses with specific options
    responses = form.get_responses(limit=10, since=1487863154)
+
+   # Print '<question>: <answer>' for all responses to this form
+   for response in responses:
+       for answer in response.answers:
+           print '{question}: {answer}'.format(question=answer.question, answer=answer.answer)
 
    # Fetch a specific response
    response = form.get_response('<response_token>')

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+coverage
+flake8
+flake8-quotes
+requests-mock

--- a/typeform/__init__.py
+++ b/typeform/__init__.py
@@ -1,0 +1,15 @@
+from .errors import (
+    TypeFormException, NotFoundException, NotAuthorizedException,
+    RateLimitException, InvalidRequestException, UnknownException
+)
+from .form import Form
+
+__all__ = [
+    'Form',
+    'TypeFormException',
+    'NotFoundException',
+    'NotAuthorizedException',
+    'RateLimitException',
+    'InvalidRequestException',
+    'UnknownException',
+]

--- a/typeform/client.py
+++ b/typeform/client.py
@@ -1,0 +1,64 @@
+import requests
+
+from .compat import urlparse
+from .errors import (NotAuthorizedException, NotFoundException, InvalidRequestException,
+                     RateLimitException, UnknownException)
+
+
+class Client(object):
+    """TypeForm API client"""
+    BASE_URL = 'https://api.typeform.com/v1/'
+
+    def __init__(self, api_key):
+        """Constructor for TypeForm API client"""
+        super(Client, self).__init__()
+
+        self.api_key = api_key
+        self._client = requests.Session()
+        self._client.headers = {
+            'User-Agent': 'python-typeform/0.1.0',
+        }
+
+    def _request(self, method, path, params=None):
+        """Helper method to make requests to the TypeForm API"""
+        # Append our API key on to the request params
+        if params is None:
+            params = dict()
+        params['key'] = self.api_key
+
+        # Get our full request URI, e.g. `form/abc123` -> `https://api.typeform.com/v1/form/abc123`
+        url = urlparse.urljoin(self.BASE_URL, path)
+
+        # Make our API request
+        resp = self._client.request(method=method, url=url, params=params)
+
+        # On 500 error we don't get JSON, so no reason to even try
+        if resp.status_code == 500:
+            raise UnknownException('typeform client received 500 response from api')
+
+        # Attempt to decode our JSON
+        # DEV: In every case (other than 500) we have gotten JSON back, but catch exception just in case
+        try:
+            data = resp.json()
+        except ValueError:
+            raise UnknownException('typeform client could not decode json from response')
+
+        # Good response, just return it
+        if resp.status_code == 200:
+            return data
+
+        # Handle any exceptions
+        message = data.get('message')
+        if resp.status_code == 404:
+            raise NotFoundException(message)
+        elif resp.status_code == 403:
+            raise NotAuthorizedException(message)
+        elif resp.status_code == 400:
+            raise InvalidRequestException(message)
+        elif resp.status_code == 429:
+            raise RateLimitException(message)
+
+        # Hmm, not sure how we got here, just raise hell
+        raise UnknownException(
+            'typeform client received unknown response status code {code!r}'.format(code=resp.status_code)
+        )

--- a/typeform/compat.py
+++ b/typeform/compat.py
@@ -1,0 +1,11 @@
+import sys
+
+PY2 = sys.version_info[0] == 2
+
+if PY2:
+    import urlparse
+else:
+    import urllib.parse as urlparse
+
+
+__all__ = ['urlparse']

--- a/typeform/errors.py
+++ b/typeform/errors.py
@@ -1,0 +1,28 @@
+class TypeFormException(Exception):
+    """Base exception that all other exceptions inherit from"""
+    pass
+
+
+class InvalidRequestException(TypeFormException):
+    """Exception raised on 400 responses from the API"""
+    pass
+
+
+class NotAuthorizedException(TypeFormException):
+    """Exception raised on 403 responses from the API"""
+    pass
+
+
+class RateLimitException(TypeFormException):
+    """Exception raised on 429 responses from the API"""
+    pass
+
+
+class UnknownException(TypeFormException):
+    """Exception raised when we receive an unknown/unexpected response from the API"""
+    pass
+
+
+class NotFoundException(TypeFormException):
+    """Exception raised when we could not the resource requested"""
+    pass

--- a/typeform/form.py
+++ b/typeform/form.py
@@ -1,0 +1,74 @@
+from .client import Client
+from .errors import NotFoundException
+from .form_response import FormResponses
+
+
+class Form(Client):
+    """TypeForm Form API client"""
+    def __init__(self, api_key, form_id):
+        """Constructor for TypeForm Form API client"""
+        super(Form, self).__init__(api_key=api_key)
+        self.form_id = form_id
+
+    def _request(self, method, params=None):
+        """Helper for making API requests for this form"""
+        path = 'form/{form_id}'.format(form_id=self.form_id)
+        return super(Form, self)._request(method, path, params=params)
+
+    def _get_params(self, **kwargs):
+        """Helper to normalize query string parameters for our request"""
+        params = dict()
+
+        # Boolean params
+        for name in ('completed', ):
+            value = kwargs.get(name)
+            if value is not None:
+                params[name] = 'true' if value else 'false'
+
+        # Number params
+        for name in ('limit', 'since', 'offset', 'until'):
+            value = kwargs.get(name)
+            if value is not None:
+                params[name] = int(value)
+
+        # Order by
+        if 'order_by' in kwargs:
+            order_by = kwargs['order_by']
+            if order_by is not None:
+                if ',' in order_by:
+                    params['order_by[]'] = order_by
+                else:
+                    params['order_by'] = order_by
+
+        # Token
+        if 'token' in kwargs:
+            params['token'] = kwargs['token']
+
+        return params
+
+    def get_responses(self, token=None, completed=None, since=None, until=None, offset=None, limit=None, order_by=None):
+        """Get a list of responses for this TypeForm Form"""
+        params = self._get_params(
+            completed=completed,
+            limit=limit,
+            offset=offset,
+            order_by=order_by,
+            since=since,
+            until=until,
+            token=token,
+        )
+
+        resp = self._request('GET', params=params)
+        return FormResponses(stats=resp.get('stats'), responses=resp.get('responses'), questions=resp.get('questions'))
+
+    def get_response(self, token):
+        """Get a specific response for this TypeForm Form"""
+        responses = self.get_responses(token=token)
+        # Check truthy *and* length since this is a class, not a list
+        if responses and len(responses) == 1:
+            return responses[0]
+
+        raise NotFoundException('typeform client could not find response with token {token!r}'.format(token=token))
+
+    def __repr__(self):
+        return 'Form(api_key={api_key!r}, form_id={form_id!r})'.format(api_key=self.api_key, form_id=self.form_id)

--- a/typeform/form_answer.py
+++ b/typeform/form_answer.py
@@ -1,0 +1,30 @@
+class FormAnswer(object):
+    """TypeForm response answer object"""
+    __slots__ = ['_question', '_question_id', '_answer']
+
+    def __init__(self, answer=None, question=None, question_id=None):
+        """Constructor for TypeForm response answer"""
+        self._answer = answer
+        self._question = question
+        self._question_id = question_id
+
+    @property
+    def question(self):
+        """The question that was asked"""
+        return self._question
+
+    @property
+    def question_id(self):
+        """The id of the question asked"""
+        return self._question_id
+
+    @property
+    def answer(self):
+        """The user's answer to the question"""
+        return self._answer
+
+    def __repr__(self):
+        return (
+            'FormAnswer(answer={answer!r}, question={question!r}, question_id={question_id!r})'
+            .format(answer=self.answer, question=self.question, question_id=self.question_id)
+        )

--- a/typeform/form_question.py
+++ b/typeform/form_question.py
@@ -1,0 +1,30 @@
+class FormQuestion(object):
+    """TypeForm form question object"""
+    __slots__ = ['_field_id', '_id', '_question']
+
+    def __init__(self, field_id=None, id=None, question=None):
+        """Constructor for TypeForm form question"""
+        self._field_id = field_id
+        self._id = id
+        self._question = question
+
+    @property
+    def field_id(self):
+        """The field_id of the question"""
+        return self._field_id
+
+    @property
+    def id(self):
+        """The id of the question"""
+        return self._id
+
+    @property
+    def question(self):
+        """The question asked by this question"""
+        return self._question
+
+    def __repr__(self):
+        return (
+            'FormQuestion(field_id={field_id!r}, id={id!r}, question={question!r})'
+            .format(field_id=self.field_id, id=self.id, question=self.question)
+        )

--- a/typeform/form_response.py
+++ b/typeform/form_response.py
@@ -1,0 +1,148 @@
+from .form_answer import FormAnswer
+from .form_question import FormQuestion
+
+
+class FormResponse(object):
+    """TypeForm form response object"""
+    __slots__ = ['_token', '_completed', '_answers', '_hidden', '_metadata', '_questions']
+
+    def __init__(self, token=None, completed=None, answers=None, hidden=None, metadata=None, questions=None):
+        """Constructor for TypeForm form response object"""
+        self._token = token
+        self._completed = bool(completed)
+        self._hidden = hidden
+        self._metadata = metadata
+        self._questions = questions
+
+        self._answers = []
+        # Generate a list of FormAnswer's from the answers provided
+        # DEV: Answers are provided in the form dict(<question_id>=<answer>)
+        for question_id, answer in answers.items():
+            question = self.get_question(question_id)
+            self._answers.append(
+                FormAnswer(answer=answer, question=question.question, question_id=question.id)
+            )
+
+    @property
+    def questions(self):
+        """The list of questions asked by the form"""
+        return self._questions
+
+    def get_question(self, id):
+        """Get a specific question by id from the list of questions"""
+        if not self.questions:
+            return None
+
+        for question in self.questions:
+            if question.id == id:
+                return question
+
+    @property
+    def completed(self):
+        """Whether or not this form was completed"""
+        return self._completed
+
+    @property
+    def answers(self):
+        """The answers provided to this form"""
+        return self._answers
+
+    @property
+    def hidden(self):
+        """Any hidden fields for this response"""
+        return self._hidden
+
+    @property
+    def metadata(self):
+        """Any metadata for this response"""
+        return self._metadata
+
+    @property
+    def token(self):
+        """This response token"""
+        return self._token
+
+    def __repr__(self):
+        return 'FormResponse(token={token!r})'.format(token=self.token)
+
+
+class FormResponses(object):
+    """TypeForm form responses collection object"""
+    __slots__ = ['_stats', '_responses', '_questions']
+
+    def __init__(self, stats=None, responses=None, questions=None):
+        """Constructor for TypeForm for responses collection object"""
+        self._stats = stats
+
+        # Convert our questions input into a list of FormQuestion objects
+        self._questions = []
+        if questions:
+            self._questions = [
+                FormQuestion(**question) for question in questions
+            ]
+
+        # Convert our responses input into a list of FormResponse objects
+        self._responses = []
+        if responses:
+            self._responses = [
+                FormResponse(
+                    token=resp.get('token'),
+                    completed=resp.get('completed'),
+                    hidden=resp.get('hidden'),
+                    metadata=resp.get('metadata'),
+                    answers=resp.get('answers'),
+                    questions=self._questions,
+                )
+                for resp in responses
+            ]
+
+    def get_question(self, id):
+        """Get a specific question by id"""
+        if not self.questions:
+            return None
+
+        for question in self.questions:
+            if question.id == id:
+                return question
+
+    @property
+    def responses(self):
+        """The responses to the form"""
+        return self._responses
+
+    def get_response(self, token):
+        """Get a specific response by it's token"""
+        if not self.responses:
+            return None
+
+        for response in self.responses:
+            if response.token == token:
+                return response
+
+    @property
+    def stats(self):
+        """Get the stats for the results"""
+        return self._stats
+
+    @property
+    def questions(self):
+        """The questions asked by this form"""
+        return self._questions
+
+    def __getitem__(self, idx):
+        """Get a specific response by index"""
+        return self.responses[idx]
+
+    def __len__(self):
+        """The number of responses"""
+        return len(self.responses)
+
+    def __iter__(self):
+        """Iterator over the responses"""
+        return iter(self.responses)
+
+    def __repr__(self):
+        return (
+            'FormResponses(questions={questions!r}, responses={responses!r})'
+            .format(questions=len(self.questions), responses=len(self.responses))
+        )

--- a/typeform/test/fixtures.py
+++ b/typeform/test/fixtures.py
@@ -1,0 +1,86 @@
+FORM_RESPONSE_200 = {
+  'http_status': 200,
+  'stats': {
+    'responses': {
+      'showing': 1,
+      'total': 13,
+      'completed': 7
+    }
+  },
+  'questions': [
+    {
+      'id': 'email_id',
+      'question': 'What is your email address?',
+      'field_id': 1234
+    },
+    {
+      'id': 'list_id_choice',
+      'question': 'What do you think of this client?',
+      'field_id': 56789
+    },
+  ],
+  'responses': [
+    {
+      'completed': '1',
+      'token': 'test_response_token',
+      'metadata': {
+        'browser': 'touch',
+        'platform': 'mobile',
+        'date_land': '2017-02-20 22:22:43',
+        'date_submit': '2017-02-20 22:50:33',
+        'user_agent': 'User-Agent',
+        'referer': 'https://underdog.typeform.com/to/test_form_id',
+        'network_id': 'abcdef'
+      },
+      'hidden': [],
+      'answers': {
+        'email_id': 'test-user@underdog.io',
+        'list_id_choice': 'It is awesome!',
+      }
+    }
+  ]
+}
+
+FORM_RESPONSE_200_EMPTY = {
+  'http_status': 200,
+  'stats': {
+    'responses': {
+      'showing': 0,
+      'total': 13,
+      'completed': 7
+    }
+  },
+  'questions': [
+    {
+      'id': 'email_id',
+      'question': 'What is your email address?',
+      'field_id': 1234
+    },
+    {
+      'id': 'list_id_choice',
+      'question': 'What do you think of this client?',
+      'field_id': 56789
+    },
+  ],
+  'responses': []
+}
+
+FORM_RESPONSE_404 = {
+    'message': 'typeform with uid test_form_id was not found',
+    'status': 404
+}
+
+FORM_RESPONSE_400 = {
+    'message': 'invalid request',
+    'status': 400
+}
+
+FORM_RESPONSE_403 = {
+    'message': 'please provide a valid api key',
+    'status': 403
+}
+
+FORM_RESPONSE_429 = {
+    'message': 'rate limit exceeded',
+    'status': 429
+}

--- a/typeform/test/test_form.py
+++ b/typeform/test/test_form.py
@@ -1,6 +1,271 @@
 from unittest import TestCase
 
+import requests_mock
+
+from typeform import Form
+from typeform import (
+    InvalidRequestException, NotAuthorizedException, NotFoundException,
+    RateLimitException, UnknownException
+)
+from . import fixtures
+
 
 class FormTestCase(TestCase):
-    def test_form(self):
-        self.assertTrue(True)
+    def test_form_get_responses(self):
+        """
+        When requesting the responses for a form
+            we get the responses we expect
+        """
+        form = Form(api_key='test_api_key', form_id='test_form_id')
+
+        with requests_mock.mock() as m:
+            m.get('https://api.typeform.com/v1/form/test_form_id', json=fixtures.FORM_RESPONSE_200)
+            responses = form.get_responses()
+
+            # Assert we made the correct request
+            self.assertEqual(m.call_count, 1)
+            last_request = m.last_request
+            self.assertDictEqual(last_request.qs, dict(
+                key=['test_api_key'],
+            ))
+
+        self.assertEqual(len(responses), 1)
+        self.assertEqual(len(responses.responses), 1)
+        self.assertEqual(len(responses.questions), 2)
+
+        question_by_id = dict((q.id, q) for q in responses.questions)
+
+        self.assertEqual(question_by_id['email_id'].id, 'email_id')
+        self.assertEqual(question_by_id['email_id'].field_id, 1234)
+        self.assertEqual(question_by_id['email_id'].question, 'What is your email address?')
+
+        self.assertEqual(question_by_id['list_id_choice'].id, 'list_id_choice')
+        self.assertEqual(question_by_id['list_id_choice'].field_id, 56789)
+        self.assertEqual(question_by_id['list_id_choice'].question, 'What do you think of this client?')
+
+        response = responses[0]
+        self.assertEqual(response.token, 'test_response_token')
+        self.assertDictEqual(
+            response.metadata,
+            dict(
+                browser='touch',
+                date_land='2017-02-20 22:22:43',
+                date_submit='2017-02-20 22:50:33',
+                network_id='abcdef',
+                platform='mobile',
+                referer='https://underdog.typeform.com/to/test_form_id',
+                user_agent='User-Agent'
+            )
+        )
+        self.assertEqual(len(response.answers), 2)
+
+        answers = response.answers
+        self.assertEqual(answers[0].answer, 'test-user@underdog.io')
+        self.assertEqual(answers[0].question, 'What is your email address?')
+        self.assertEqual(answers[0].question_id, 'email_id')
+        self.assertEqual(answers[1].answer, 'It is awesome!')
+        self.assertEqual(answers[1].question, 'What do you think of this client?')
+        self.assertEqual(answers[1].question_id, 'list_id_choice')
+
+    def test_form_get_responses_500(self):
+        """
+        When requesting the responses for a form
+            when the API responds with a 500 error
+                 we raise an UnknownException
+        """
+        form = Form(api_key='test_api_key', form_id='test_form_id')
+
+        with requests_mock.mock() as m:
+            m.get('https://api.typeform.com/v1/form/test_form_id', status_code=500)
+
+            with self.assertRaises(UnknownException):
+                form.get_responses()
+
+    def test_form_get_responses_404(self):
+        """
+        When requesting the responses for a form
+            when the API responds with a 404 error
+                 we raise a NotFoundException
+        """
+        form = Form(api_key='test_api_key', form_id='test_form_id')
+
+        with requests_mock.mock() as m:
+            m.get('https://api.typeform.com/v1/form/test_form_id', status_code=404, json=fixtures.FORM_RESPONSE_404)
+
+            with self.assertRaises(NotFoundException):
+                form.get_responses()
+
+    def test_form_get_responses_400(self):
+        """
+        When requesting the responses for a form
+            when the API responds with a 400 error
+                 we raise a InvalidRequestException
+        """
+        form = Form(api_key='test_api_key', form_id='test_form_id')
+
+        with requests_mock.mock() as m:
+            m.get('https://api.typeform.com/v1/form/test_form_id', status_code=400, json=fixtures.FORM_RESPONSE_400)
+
+            with self.assertRaises(InvalidRequestException):
+                form.get_responses()
+
+    def test_form_get_responses_403(self):
+        """
+        When requesting the responses for a form
+            when the API responds with a 403 error
+                 we raise a NotAuthorizedException
+        """
+        form = Form(api_key='test_api_key', form_id='test_form_id')
+
+        with requests_mock.mock() as m:
+            m.get('https://api.typeform.com/v1/form/test_form_id', status_code=403, json=fixtures.FORM_RESPONSE_403)
+
+            with self.assertRaises(NotAuthorizedException):
+                form.get_responses()
+
+    def test_form_get_responses_429(self):
+        """
+        When requesting the responses for a form
+            when the API responds with a 429 error
+                 we raise a RateLimitException
+        """
+        form = Form(api_key='test_api_key', form_id='test_form_id')
+
+        with requests_mock.mock() as m:
+            m.get('https://api.typeform.com/v1/form/test_form_id', status_code=429, json=fixtures.FORM_RESPONSE_429)
+
+            with self.assertRaises(RateLimitException):
+                form.get_responses()
+
+    def test_form_get_responses_unknown_code(self):
+        """
+        When requesting the responses for a form
+            when the API responds with an unhandled response code
+                 we raise a UnknownException
+        """
+        form = Form(api_key='test_api_key', form_id='test_form_id')
+
+        with requests_mock.mock() as m:
+            # DEV: We need to provide a valid json response otherwise we'll fail at parsing
+            m.get('https://api.typeform.com/v1/form/test_form_id', status_code=302, json=dict())
+
+            with self.assertRaises(UnknownException):
+                form.get_responses()
+
+    def test_form_get_responses_non_json(self):
+        """
+        When requesting the responses for a form
+            when the API responds with a non-json response
+                 we raise a UnknownException
+        """
+        form = Form(api_key='test_api_key', form_id='test_form_id')
+
+        with requests_mock.mock() as m:
+            m.get('https://api.typeform.com/v1/form/test_form_id', status_code=200, text='I am not json')
+
+            with self.assertRaises(UnknownException):
+                form.get_responses()
+
+    def test_form_get_responses_filters(self):
+        """
+        When requesting the responses for a form
+            when requesting with filters
+                the request does not fail
+                we make the appropriate request
+        """
+        form = Form(api_key='test_api_key', form_id='test_form_id')
+
+        with requests_mock.mock() as m:
+            m.get('https://api.typeform.com/v1/form/test_form_id', status_code=200, json=fixtures.FORM_RESPONSE_200)
+            response = form.get_responses(
+                token='test_response_token',
+                completed=True,
+                limit=5, offset=5,
+                since=1234, until=56789,
+            )
+            self.assertIsNotNone(response)
+
+            # Assert we made the correct request
+            self.assertEqual(m.call_count, 1)
+            last_request = m.last_request
+            self.assertDictEqual(last_request.qs, dict(
+                completed=['true'],
+                key=['test_api_key'],
+                limit=['5'],
+                offset=['5'],
+                since=['1234'],
+                token=['test_response_token'],
+                until=['56789'],
+            ))
+
+    def test_form_get_responses_sorting(self):
+        """
+        When requesting the responses for a form
+            when requesting with order by sorting
+                the request does not fail
+                we make the appropriate request
+        """
+        form = Form(api_key='test_api_key', form_id='test_form_id')
+
+        with requests_mock.mock() as m:
+            m.get('https://api.typeform.com/v1/form/test_form_id', status_code=200, json=fixtures.FORM_RESPONSE_200)
+            response = form.get_responses(order_by='date_land,desc')
+            self.assertIsNotNone(response)
+
+            # Assert we made the correct request
+            self.assertEqual(m.call_count, 1)
+            last_request = m.last_request
+            self.assertDictEqual(last_request.qs, {
+                'key': ['test_api_key'],
+                'order_by[]': ['date_land,desc'],
+            })
+
+        with requests_mock.mock() as m:
+            m.get('https://api.typeform.com/v1/form/test_form_id', status_code=200, json=fixtures.FORM_RESPONSE_200)
+            response = form.get_responses(order_by='date_land')
+            self.assertIsNotNone(response)
+
+            # Assert we made the correct request
+            self.assertEqual(m.call_count, 1)
+            last_request = m.last_request
+            self.assertDictEqual(last_request.qs, {
+                'key': ['test_api_key'],
+                'order_by': ['date_land'],
+            })
+
+    def test_form_get_response(self):
+        """
+        When requesting a single response for a form
+            the request does not fail
+            we make the appropriate request
+        """
+        form = Form(api_key='test_api_key', form_id='test_form_id')
+
+        with requests_mock.mock() as m:
+            m.get('https://api.typeform.com/v1/form/test_form_id', status_code=200, json=fixtures.FORM_RESPONSE_200)
+            response = form.get_response(token='test_response_token')
+            self.assertIsNotNone(response)
+
+            # Assert we made the correct request
+            self.assertEqual(m.call_count, 1)
+            last_request = m.last_request
+            self.assertDictEqual(last_request.qs, {
+                'key': ['test_api_key'],
+                'token': ['test_response_token'],
+            })
+
+    def test_form_get_response_not_found(self):
+        """
+        When requesting a single response for a form
+            when the requested response is not in the response
+                we raise a NotFoundException
+
+        """
+        form = Form(api_key='test_api_key', form_id='test_form_id')
+
+        with requests_mock.mock() as m:
+            m.get('https://api.typeform.com/v1/form/test_form_id',
+                  status_code=200, json=fixtures.FORM_RESPONSE_200_EMPTY)
+
+            with self.assertRaises(NotFoundException):
+                form.get_response(token='test_response_token')


### PR DESCRIPTION
This is an initial implementation of a `typeform` API client for interacting with form responses from TypeForm's API.

There are a few things missing here that we should work on, like better documentation, better test coverage (at 93% right now, some files are a little lower than that though). However, this should be a decent enough first implementation where we can start using it.