### PR TITLE
Support question 'group' property

### DIFF
--- a/typeform/form_question.py
+++ b/typeform/form_question.py
@@ -1,10 +1,11 @@
 class FormQuestion(object):
     """TypeForm form question object"""
-    __slots__ = ['_field_id', '_id', '_question']
+    __slots__ = ['_field_id', '_group', '_id', '_question']
 
-    def __init__(self, field_id=None, id=None, question=None):
+    def __init__(self, field_id=None, group=None, id=None, question=None):
         """Constructor for TypeForm form question"""
         self._field_id = field_id
+        self._group = group
         self._id = id
         self._question = question
 
@@ -12,6 +13,11 @@ class FormQuestion(object):
     def field_id(self):
         """The field_id of the question"""
         return self._field_id
+
+    @property
+    def group(self):
+        """The field_id of the question"""
+        return self._group
 
     @property
     def id(self):
@@ -25,6 +31,6 @@ class FormQuestion(object):
 
     def __repr__(self):
         return (
-            'FormQuestion(field_id={field_id!r}, id={id!r}, question={question!r})'
-            .format(field_id=self.field_id, id=self.id, question=self.question)
+            'FormQuestion(field_id={field_id!r}, group={group!r}, id={id!r}, question={question!r})'
+            .format(field_id=self.field_id, group=self.group, id=self.id, question=self.question)
         )

--- a/typeform/test/fixtures.py
+++ b/typeform/test/fixtures.py
@@ -18,6 +18,17 @@ FORM_RESPONSE_200 = {
       'question': 'What do you think of this client?',
       'field_id': 56789
     },
+    {
+      'id': 'group_1324',
+      'question': 'Question group',
+      'field_id': 1324
+    },
+    {
+      'id': 'quest_id',
+      'question': 'What is your quest?',
+      'field_id': 5768,
+      'group': 'group_1324'
+    }
   ],
   'responses': [
     {

--- a/typeform/test/test_form.py
+++ b/typeform/test/test_form.py
@@ -31,17 +31,29 @@ class FormTestCase(TestCase):
 
         self.assertEqual(len(responses), 1)
         self.assertEqual(len(responses.responses), 1)
-        self.assertEqual(len(responses.questions), 2)
+        self.assertEqual(len(responses.questions), 4)
 
         question_by_id = dict((q.id, q) for q in responses.questions)
 
         self.assertEqual(question_by_id['email_id'].id, 'email_id')
         self.assertEqual(question_by_id['email_id'].field_id, 1234)
         self.assertEqual(question_by_id['email_id'].question, 'What is your email address?')
+        self.assertIsNone(question_by_id['email_id'].group)
 
         self.assertEqual(question_by_id['list_id_choice'].id, 'list_id_choice')
         self.assertEqual(question_by_id['list_id_choice'].field_id, 56789)
         self.assertEqual(question_by_id['list_id_choice'].question, 'What do you think of this client?')
+        self.assertIsNone(question_by_id['list_id_choice'].group)
+
+        self.assertEqual(question_by_id['group_1324'].id, 'group_1324')
+        self.assertEqual(question_by_id['group_1324'].field_id, 1324)
+        self.assertEqual(question_by_id['group_1324'].question, 'Question group')
+        self.assertIsNone(question_by_id['group_1324'].group)
+
+        self.assertEqual(question_by_id['quest_id'].id, 'quest_id')
+        self.assertEqual(question_by_id['quest_id'].field_id, 5768)
+        self.assertEqual(question_by_id['quest_id'].question, 'What is your quest?')
+        self.assertEqual(question_by_id['quest_id'].group, 'group_1324')
 
         response = responses[0]
         self.assertEqual(response.token, 'test_response_token')


### PR DESCRIPTION
Fixes #2 

In Typeform you are able to group questions together, which will then provide a `group` property for those questions. This PR updates the `FormQuestion` class to look for this `group` property.