### PR TITLE
Activate mocking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist
 .DS_STORE
 .coverage
 .idea
+.tox

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist
 .eggs
 .DS_STORE
 .coverage
+.idea

--- a/README.md
+++ b/README.md
@@ -153,4 +153,4 @@ result: str = responses.delete('abc123' ['token2', 'token3'])
 
 ## Tests
 
-⚠️⚠️⚠️⚠️⚠️ Don't use your own token to run tests, use a demo account with only few forms
+Check typeform/test/fixtures.py to configure test run.

--- a/typeform/client.py
+++ b/typeform/client.py
@@ -39,7 +39,7 @@ class Client(object):
         if type(body) is dict and body.get('code', None) is not None:
             raise Exception(body.get('description'))
         elif result.status_code >= 400:
-            raise Exception(result.reason)
+            raise Exception(' '.join([str(result.status_code),result.reason]))
         elif len(result.text) == 0:
             return 'OK'
         else:

--- a/typeform/test/fixtures.py
+++ b/typeform/test/fixtures.py
@@ -1,11 +1,15 @@
 import os
 
+# Set to True to use mocked requests.
+# A False here will make the test suite hit the real API. Set TOKEN and WORKSPACE below to make it work.
+MOCK = False
+
 # Don't use your own account for this, this will delete pretty much everything you have!
 TOKEN = os.environ.get('TYPEFORM_TOKEN')
 
 # Tests will be scoped to this workspace.
-WORKSPACE = 'https://api.typeform.com/workspaces/[YOUR WORKSPACE ID]'
+WORKSPACE = 'https://api.typeform.com/workspaces/hn3dNa'
 WORKSPACE_ID = WORKSPACE.split('/')[-1]
 
-if not TOKEN or '[YOUR WORKSPACE ID]' in WORKSPACE:
+if MOCK and (not TOKEN or '[YOUR WORKSPACE ID]' in WORKSPACE):
     raise Exception("You need to setup TOKEN and WORKSPACE in fixtures.py")

--- a/typeform/test/fixtures.py
+++ b/typeform/test/fixtures.py
@@ -2,3 +2,10 @@ import os
 
 # Don't use your own account for this, this will delete pretty much everything you have!
 TOKEN = os.environ.get('TYPEFORM_TOKEN')
+
+# Tests will be scoped to this workspace.
+WORKSPACE = 'https://api.typeform.com/workspaces/[YOUR WORKSPACE ID]'
+WORKSPACE_ID = WORKSPACE.split('/')[-1]
+
+if not TOKEN or '[YOUR WORKSPACE ID]' in WORKSPACE:
+    raise Exception("You need to setup TOKEN and WORKSPACE in fixtures.py")

--- a/typeform/test/fixtures.py
+++ b/typeform/test/fixtures.py
@@ -1,11 +1,14 @@
 import os
 
-# Don't use your own account for this, this will delete pretty much everything you have!
+# Set to True to use mocked requests.
+# A False here will make the test suite hit the real API. Set TOKEN and WORKSPACE below to make it work.
+MOCK = True
+
 TOKEN = os.environ.get('TYPEFORM_TOKEN')
 
 # Tests will be scoped to this workspace.
 WORKSPACE = 'https://api.typeform.com/workspaces/[YOUR WORKSPACE ID]'
 WORKSPACE_ID = WORKSPACE.split('/')[-1]
 
-if not TOKEN or '[YOUR WORKSPACE ID]' in WORKSPACE:
+if MOCK and (not TOKEN or '[YOUR WORKSPACE ID]' in WORKSPACE):
     raise Exception("You need to setup TOKEN and WORKSPACE in fixtures.py")

--- a/typeform/test/test_forms.py
+++ b/typeform/test/test_forms.py
@@ -2,7 +2,7 @@ from unittest import TestCase
 import requests_mock
 import urllib.parse
 
-from .fixtures import TOKEN, WORKSPACE, WORKSPACE_ID
+from .fixtures import MOCK, TOKEN, WORKSPACE, WORKSPACE_ID
 
 from typeform import Typeform
 from typeform.constants import API_BASE_URL
@@ -11,20 +11,24 @@ from typeform.constants import API_BASE_URL
 class FormsTestCase(TestCase):
     def setUp(self):
         self.forms = Typeform(TOKEN).forms
-        form = self.forms.create(dict(title="Form's test form", workspace={'href': WORKSPACE}))
-        self.formID = form.get('id')
+        if not MOCK:
+            form = self.forms.create(dict(title="Form's test form", workspace={'href': WORKSPACE}))
+            self.formID = form.get('id')
+        else:
+            self.formID = "MOCK-FORM-ID"
 
     def tearDown(self):
-        list = self.forms.list(workspaceId=WORKSPACE_ID)
-        forms = list.get('items', [])
-        for form in forms:
-            self.forms.delete(form.get('id'))
+        if not MOCK:
+            list = self.forms.list(workspaceId=WORKSPACE_ID)
+            forms = list.get('items', [])
+            for form in forms:
+                self.forms.delete(form.get('id'))
 
     def test_forms_returns_method_and_path(self):
         """
         get all forms has the correct method and path
         """
-        with requests_mock.mock() as m:
+        with requests_mock.mock(real_http=not MOCK) as m:
             m.get(API_BASE_URL+'/forms', json={})
             self.forms.list(workspaceId=WORKSPACE_ID)
 
@@ -36,7 +40,7 @@ class FormsTestCase(TestCase):
         """
         paramters are sent correctly
         """
-        with requests_mock.mock() as m:
+        with requests_mock.mock(real_http=not MOCK) as m:
             m.get(API_BASE_URL+'/forms', json={})
             self.forms.list(page=2, pageSize=10, search='forms_correct_params', workspaceId=WORKSPACE_ID)
 
@@ -64,7 +68,7 @@ class FormsTestCase(TestCase):
         """
         get sets get method
         """
-        with requests_mock.mock() as m:
+        with requests_mock.mock(real_http=not MOCK) as m:
             m.get(API_BASE_URL+'/forms/'+self.formID, json={})
             self.forms.get(self.formID)
 
@@ -75,30 +79,31 @@ class FormsTestCase(TestCase):
         """
         update updates a form
         """
-        title = 'forms_update_updates_a_form'
-        result = self.forms.update(self.formID, data={
-            'title': title
-        })
+        with requests_mock.mock(real_http=not MOCK) as m:
+            title = 'forms_update_updates_a_form'
+            m.put(API_BASE_URL + '/forms/' + self.formID, json=dict(title=title))
+            result = self.forms.update(self.formID, data={
+                'title': title
+            })
 
-        self.assertEqual(result.get('title'), title)
+            self.assertEqual(result.get('title'), title)
 
     def test_forms_update_as_patch_updates_a_form(self):
         """
         update as patch updates a form
         """
-        result = self.forms.update(self.formID, patch=True, data=[{
-            'op': 'replace',
-            'path': '/title',
-            'value': 'forms_update_as_patch_updates_a_form'
-        }])
+        with requests_mock.mock(real_http=not MOCK) as m:
+            m.patch(API_BASE_URL+'/forms/'+self.formID, json="OK")
+            result = self.forms.update(self.formID, patch=True, data=[
+                dict(op='replace', path='/title', value='forms_update_as_patch_updates_a_form')])
 
-        self.assertEqual(result, 'OK')
+            self.assertEqual(result, 'OK')
 
     def test_forms_update_sets_put_method_in_request_by_default(self):
         """
         update sets put method in request by default
         """
-        with requests_mock.mock() as m:
+        with requests_mock.mock(real_http=not MOCK) as m:
             m.put(API_BASE_URL+'/forms/'+self.formID, json={})
             self.forms.update(self.formID, data={
                 'title': 'forms_update_sets_put_method_in_request_by_default'
@@ -112,20 +117,26 @@ class FormsTestCase(TestCase):
         """
         delete removes the correct uid form
         """
-        get1Result = self.forms.get(self.formID)
-        self.assertEqual(get1Result.get('id'), self.formID)
-        self.forms.delete(self.formID)
-        try:
-            self.forms.get(self.formID)
-        except Exception as err:
-            error = str(err)
-        self.assertEqual(error, 'Non existing form with uid %s' % self.formID)
+        with requests_mock.mock(real_http=not MOCK) as m:
+            m.get(API_BASE_URL + '/forms/{}'.format(self.formID), json=dict(id=str(self.formID)))
+            m.delete(API_BASE_URL + '/forms/{}'.format(self.formID), json={})
+
+            get_one_result = self.forms.get(self.formID)
+            self.assertEqual(get_one_result.get('id'), self.formID)
+            self.forms.delete(self.formID)
+            m.get(API_BASE_URL + '/forms/{}'.format(self.formID),
+                  json=dict(code="FORM_NOT_FOUND", description="Non existing form with uid {}".format(self.formID)))
+            try:
+                self.forms.get(self.formID)
+            except Exception as err:
+                error = str(err)
+            self.assertEqual(error, 'Non existing form with uid %s' % self.formID)
 
     def test_forms_create_has_the_correct_path_and_method(self):
         """
         create has the correct path and method
         """
-        with requests_mock.mock() as m:
+        with requests_mock.mock(real_http=not MOCK) as m:
             m.post(API_BASE_URL+'/forms', json={})
             self.forms.create(dict(title='forms_create_has_the_correct_path_and_method', workspace={'href': WORKSPACE}))
 
@@ -138,20 +149,24 @@ class FormsTestCase(TestCase):
         """
         create creates a new form
         """
-        createResult = self.forms.create(dict(title='forms_create_creates_a_new_form', workspace={'href': WORKSPACE}))
+        with requests_mock.mock(real_http=not MOCK) as m:
+            m.post(API_BASE_URL + '/forms', json=dict(id=str(self.formID)))
+            m.get(API_BASE_URL + '/forms/{}'.format(self.formID), json=dict(id=str(self.formID)))
 
-        formID = createResult.get('id')
+            create_result = self.forms.create(dict(title='forms_create_creates_a_new_form', workspace={'href': WORKSPACE}))
 
-        getResult = self.forms.get(formID)
+            formID = create_result.get('id')
 
-        self.assertIsNone(createResult.get('code', None))
-        self.assertEqual(getResult.get('id'), formID)
+            result = self.forms.get(formID)
+
+            self.assertIsNone(create_result.get('code', None))
+            self.assertEqual(result.get('id'), formID)
 
     def test_forms_get_messages_has_the_correct_path_and_method(self):
         """
         get messages has the correct path and method
         """
-        with requests_mock.mock() as m:
+        with requests_mock.mock(real_http=not MOCK) as m:
             m.get(API_BASE_URL+'/forms/'+self.formID+'/messages', json={})
             self.forms.messages.get(self.formID)
 
@@ -164,7 +179,7 @@ class FormsTestCase(TestCase):
         """
         update messages has the correct path and method
         """
-        with requests_mock.mock() as m:
+        with requests_mock.mock(real_http=not MOCK) as m:
             m.put(API_BASE_URL+'/forms/'+self.formID+'/messages')
             self.forms.messages.update(self.formID)
 

--- a/typeform/test/test_responses.py
+++ b/typeform/test/test_responses.py
@@ -2,7 +2,7 @@ from unittest import TestCase
 import requests_mock
 import urllib.parse
 
-from .fixtures import TOKEN
+from .fixtures import TOKEN, WORKSPACE, WORKSPACE_ID
 
 from typeform import Typeform
 from typeform.constants import API_BASE_URL
@@ -12,13 +12,11 @@ class ResponsesTestCase(TestCase):
     def setUp(self):
         self.forms = Typeform(TOKEN).forms
         self.responses = Typeform(TOKEN).responses
-        form = self.forms.create({
-            'title': 'title'
-        })
+        form = self.forms.create((dict(title="Responses's test form", workspace={'href': WORKSPACE})))
         self.formID = form.get('id')
 
     def tearDown(self):
-        list = self.forms.list()
+        list = self.forms.list(workspaceId=WORKSPACE_ID)
         forms = list.get('items', [])
         for form in forms:
             self.forms.delete(form.get('id'))
@@ -65,7 +63,7 @@ class ResponsesTestCase(TestCase):
 
     def test_list_fetches_responses_with_params(self):
         """
-        get all responses does not throw an error with paramters
+        get all responses does not throw an error with parameters
         """
         result = self.responses.list(
             self.formID, pageSize=100, since='2000-01-01T00:00:00Z', completed=True, fields=['1', '2']

--- a/typeform/test/test_responses.py
+++ b/typeform/test/test_responses.py
@@ -2,7 +2,7 @@ from unittest import TestCase
 import requests_mock
 import urllib.parse
 
-from .fixtures import TOKEN, WORKSPACE, WORKSPACE_ID
+from .fixtures import MOCK, TOKEN, WORKSPACE, WORKSPACE_ID
 
 from typeform import Typeform
 from typeform.constants import API_BASE_URL
@@ -12,20 +12,24 @@ class ResponsesTestCase(TestCase):
     def setUp(self):
         self.forms = Typeform(TOKEN).forms
         self.responses = Typeform(TOKEN).responses
-        form = self.forms.create((dict(title="Responses's test form", workspace={'href': WORKSPACE})))
-        self.formID = form.get('id')
+        if not MOCK:
+            form = self.forms.create((dict(title="Responses's test form", workspace={'href': WORKSPACE})))
+            self.formID = form.get('id')
+        else:
+            self.formID = "MOCK-FORM-ID"
 
     def tearDown(self):
-        list = self.forms.list(workspaceId=WORKSPACE_ID)
-        forms = list.get('items', [])
-        for form in forms:
-            self.forms.delete(form.get('id'))
+        if not MOCK:
+            list = self.forms.list(workspaceId=WORKSPACE_ID)
+            forms = list.get('items', [])
+            for form in forms:
+                self.forms.delete(form.get('id'))
 
     def test_list_returns_method_and_path(self):
         """
         get all responses has the correct method and path
         """
-        with requests_mock.mock() as m:
+        with requests_mock.mock(real_http=not MOCK) as m:
             url = API_BASE_URL+'/forms/'+self.formID+'/responses'
             m.get(url, json={})
             self.responses.list(self.formID)
@@ -38,7 +42,7 @@ class ResponsesTestCase(TestCase):
         """
         paramters are sent correctly
         """
-        with requests_mock.mock() as m:
+        with requests_mock.mock(real_http=not MOCK) as m:
             url = API_BASE_URL+'/forms/'+self.formID+'/responses'
             m.get(url, json={})
             self.responses.list(
@@ -58,23 +62,27 @@ class ResponsesTestCase(TestCase):
         """
         get all responses does not throw an error
         """
-        result = self.responses.list(self.formID)
-        self.assertEqual(result.pop('total_items'), 0)
+        with requests_mock.mock(real_http=not MOCK) as m:
+            m.get(API_BASE_URL+'/forms/{}/responses'.format(self.formID), json=dict(total_items=0))
+            result = self.responses.list(self.formID)
+            self.assertEqual(result.pop('total_items'), 0)
 
     def test_list_fetches_responses_with_params(self):
         """
         get all responses does not throw an error with parameters
         """
-        result = self.responses.list(
-            self.formID, pageSize=100, since='2000-01-01T00:00:00Z', completed=True, fields=['1', '2']
-        )
-        self.assertEqual(result.pop('total_items'), 0)
+        with requests_mock.mock(real_http=not MOCK) as m:
+            m.get(API_BASE_URL+'/forms/{}/responses'.format(self.formID), json=dict(total_items=0))
+            result = self.responses.list(
+                self.formID, pageSize=100, since='2000-01-01T00:00:00Z', completed=True, fields=['1', '2']
+            )
+            self.assertEqual(result.pop('total_items'), 0)
 
     def test_delete_one_token_returns_method_and_path(self):
         """
         delete response has the correct method and path when deleting one token
         """
-        with requests_mock.mock() as m:
+        with requests_mock.mock(real_http=not MOCK) as m:
             url = API_BASE_URL+'/forms/'+self.formID+'/responses?included_tokens=1'
             m.delete(url, json={})
             self.responses.delete(self.formID, includedTokens='1')
@@ -87,7 +95,7 @@ class ResponsesTestCase(TestCase):
         """
         delete response has the correct method and path when deleting multiple tokens
         """
-        with requests_mock.mock() as m:
+        with requests_mock.mock(real_http=not MOCK) as m:
             url = API_BASE_URL+'/forms/'+self.formID+'/responses?included_tokens=1%2C2%2C3'
             m.delete(url, json={})
             self.responses.delete(self.formID, includedTokens=['1', '2', '3'])


### PR DESCRIPTION
- Tests are now scoped to a single workspace. 
- The test suite does no longer delete all forms of an account.
- Mocking is now effective.
- Test is configurable and supports both Mock and live API.