### PR TITLE
Readme, Usage section: rename forms to forms_dict

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ pip install typeform
 
 ``` python
   # will retrieve all forms
-  forms: dict = typeform.forms.list()
+  forms_dict: dict = typeform.forms.list()
 ```
 
 ## Reference


### PR DESCRIPTION
Avoid name collision with `forms` below referring to the Forms object